### PR TITLE
Add unit tests for action modules

### DIFF
--- a/__tests__/claude.test.ts
+++ b/__tests__/claude.test.ts
@@ -1,0 +1,43 @@
+import { jest } from '@jest/globals'
+import * as core from '../__fixtures__/core.js'
+import { generatePRDescription } from '../src/claude.js'
+
+jest.unstable_mockModule('@actions/core', () => core)
+
+describe('generatePRDescription', () => {
+  const prContext = {
+    prInfo: {
+      number: 1,
+      title: 'Add feature',
+      author: 'user',
+      baseSha: 'base',
+      headSha: 'head',
+      url: 'url'
+    },
+    commitMessages: 'commit1',
+    diff: 'diff content'
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('generates description using fetch mock', async () => {
+    const apiResponse = {
+      content: [{ type: 'text', text: 'desc' }],
+      usage: { input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0 }
+    }
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify(apiResponse), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        }) as any
+      )
+
+    const result = await generatePRDescription('key', prContext)
+    expect(result).toBe('desc')
+    expect(fetchMock).toHaveBeenCalled()
+  })
+})

--- a/__tests__/github.test.ts
+++ b/__tests__/github.test.ts
@@ -1,0 +1,122 @@
+import { jest } from '@jest/globals'
+import * as core from '../__fixtures__/core.js'
+
+const mockContext = { repo: { owner: 'octo', repo: 'test' }, payload: {} }
+
+jest.unstable_mockModule('@actions/core', () => core)
+jest.unstable_mockModule('@actions/github', () => ({ context: mockContext }))
+
+const { generateDiff, getCommitMessages, updatePRDescription } = await import('../src/github.js')
+
+describe('github helpers', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('generateDiff', () => {
+    it('returns diff string', async () => {
+      const diff = 'some diff'
+      const octokit = {
+        rest: {
+          repos: {
+            compareCommitsWithBasehead: (jest.fn() as any).mockResolvedValue({
+              data: diff
+            } as any)
+          }
+        }
+      } as any
+
+      const result = await generateDiff(octokit, 'base', 'head')
+      expect(result).toBe(diff)
+      expect(octokit.rest.repos.compareCommitsWithBasehead).toHaveBeenCalledWith({
+        owner: 'octo',
+        repo: 'test',
+        basehead: 'base...head',
+        mediaType: { format: 'diff' }
+      })
+    })
+
+    it('throws when API fails', async () => {
+      const octokit = {
+        rest: {
+          repos: {
+            compareCommitsWithBasehead: (jest.fn() as any).mockRejectedValue(
+              new Error('bad') as any
+            )
+          }
+        }
+      } as any
+
+      await expect(generateDiff(octokit, 'a', 'b')).rejects.toThrow('Failed to generate diff: Error: bad')
+    })
+  })
+
+  describe('getCommitMessages', () => {
+    it('returns commit messages', async () => {
+      const commits = [
+        { sha: 'abcdef1', commit: { message: 'msg1\nbody' } },
+        { sha: 'abcdef2', commit: { message: 'msg2' } }
+      ]
+      const octokit = {
+        rest: {
+          pulls: {
+            listCommits: (jest.fn() as any).mockResolvedValue({
+              data: commits
+            } as any)
+          }
+        }
+      } as any
+
+      const result = await getCommitMessages(octokit, 5)
+      expect(result).toBe('abcdef1 msg1\nabcdef2 msg2')
+      expect(octokit.rest.pulls.listCommits).toHaveBeenCalledWith({
+        owner: 'octo',
+        repo: 'test',
+        pull_number: 5
+      })
+    })
+
+    it('throws when API fails', async () => {
+      const octokit = {
+        rest: {
+          pulls: {
+            listCommits: (jest.fn() as any).mockRejectedValue(
+              new Error('oops') as any
+            )
+          }
+        }
+      } as any
+      await expect(getCommitMessages(octokit, 1)).rejects.toThrow('Failed to get commit messages: Error: oops')
+    })
+  })
+
+  describe('updatePRDescription', () => {
+    it('updates description via octokit', async () => {
+      const octokit = {
+        rest: {
+          pulls: {
+            update: (jest.fn() as any).mockResolvedValue({} as any)
+          }
+        }
+      } as any
+      await updatePRDescription(octokit, 3, 'body')
+      expect(octokit.rest.pulls.update).toHaveBeenCalledWith({
+        owner: 'octo',
+        repo: 'test',
+        pull_number: 3,
+        body: 'body'
+      })
+    })
+
+    it('throws when update fails', async () => {
+      const octokit = {
+        rest: {
+          pulls: {
+            update: (jest.fn() as any).mockRejectedValue(new Error('no') as any)
+          }
+        }
+      } as any
+      await expect(updatePRDescription(octokit, 2, 'x')).rejects.toThrow('Failed to update PR description: Error: no')
+    })
+  })
+})

--- a/__tests__/validation.test.ts
+++ b/__tests__/validation.test.ts
@@ -1,0 +1,130 @@
+import { jest } from '@jest/globals'
+import * as core from '../__fixtures__/core.js'
+
+const mockContext: any = { eventName: 'pull_request', payload: {}, repo: {} }
+
+jest.unstable_mockModule('@actions/core', () => core)
+jest.unstable_mockModule('@actions/github', () => ({ context: mockContext }))
+
+const {
+  validatePullRequestEvent,
+  validatePullRequestAction,
+  extractPRInfo,
+  getApiKeys
+} = await import('../src/validation.js')
+
+describe('validation helpers', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    mockContext.eventName = 'pull_request'
+    mockContext.payload = {}
+  })
+
+  describe('validatePullRequestEvent', () => {
+    it('passes for pull_request event', () => {
+      expect(() => validatePullRequestEvent()).not.toThrow()
+    })
+
+    it('throws for other events', () => {
+      mockContext.eventName = 'push'
+      expect(() => validatePullRequestEvent()).toThrow(
+        'This action can only be used in pull request events.'
+      )
+    })
+  })
+
+  describe('validatePullRequestAction', () => {
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => undefined) as never)
+
+    afterEach(() => {
+      exitSpy.mockClear()
+    })
+
+    it('exits when action is not allowed', () => {
+      mockContext.payload.action = 'closed'
+      validatePullRequestAction()
+      expect(core.info).toHaveBeenCalledWith('Skipping action for PR action: closed')
+      expect(exitSpy).toHaveBeenCalledWith(0)
+    })
+
+    it('does nothing for allowed action', () => {
+      mockContext.payload.action = 'opened'
+      validatePullRequestAction()
+      expect(exitSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('extractPRInfo', () => {
+    it('extracts info from context', () => {
+      mockContext.payload.pull_request = {
+        number: 1,
+        title: 't',
+        user: { login: 'me' },
+        base: { sha: 'a' },
+        head: { sha: 'b' },
+        html_url: 'url'
+      }
+      expect(extractPRInfo()).toEqual({
+        number: 1,
+        title: 't',
+        author: 'me',
+        baseSha: 'a',
+        headSha: 'b',
+        url: 'url'
+      })
+    })
+
+    it('throws when pull_request missing', () => {
+      delete mockContext.payload.pull_request
+      expect(() => extractPRInfo()).toThrow('No pull request found in context')
+    })
+
+    it('throws when fields missing', () => {
+      mockContext.payload.pull_request = {
+        number: 1,
+        title: '',
+        user: { login: 'me' },
+        base: { sha: 'a' },
+        head: { sha: 'b' },
+        html_url: 'url'
+      }
+      expect(() => extractPRInfo()).toThrow(
+        'Required PR fields are missing (title, author, base SHA, head SHA, or URL)'
+      )
+    })
+  })
+
+  describe('getApiKeys', () => {
+    const envBackup = { ...process.env }
+
+    afterEach(() => {
+      process.env = { ...envBackup }
+    })
+
+    it('returns keys from env', () => {
+      core.getInput.mockReturnValueOnce('') // anthropic
+      core.getInput.mockReturnValueOnce('') // github token
+      process.env.ANTHROPIC_API_KEY = 'a'
+      process.env.GITHUB_TOKEN = 'g'
+      expect(getApiKeys()).toEqual({ anthropicApiKey: 'a', githubToken: 'g' })
+    })
+
+    it('throws when anthropic key missing', () => {
+      core.getInput.mockReturnValueOnce('')
+      core.getInput.mockReturnValueOnce('token')
+      delete process.env.ANTHROPIC_API_KEY
+      process.env.GITHUB_TOKEN = 'g'
+      expect(() => getApiKeys()).toThrow('Anthropic API key not found')
+    })
+
+    it('throws when github token missing', () => {
+      core.getInput.mockReturnValueOnce('key')
+      core.getInput.mockReturnValueOnce('')
+      process.env.ANTHROPIC_API_KEY = 'a'
+      delete process.env.GITHUB_TOKEN
+      expect(() => getApiKeys()).toThrow('GitHub token not found')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- create Jest unit tests covering github.ts and validation.ts
- add a fetch-based test for generatePRDescription in claude.ts

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68400171620c832d933b2a1c3cd35970